### PR TITLE
Change how the frontend process is started from a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,6 @@
 FROM node:12-alpine
-
-ENV PORT 3000
-
-# Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-# Install app dependencies
-COPY package.json /usr/src/app/
-RUN npm install
-
-# Bundle app source
 COPY . /usr/src/app
-
-RUN npm run build
-
+WORKDIR /usr/src/app
+RUN npm install
+ENTRYPOINT [ "npm", "run", "docker-build" ]
 EXPOSE 8000
-CMD [ "npm", "run", "start" ]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next",
     "start": "next start -p 8000",
     "build": "next build",
+    "docker-build": "next build && next start -p 8000",
     "now-build": "next build",
     "precommit": "lint-staged"
   },


### PR DESCRIPTION
- Add a script in the package.json:
	- It will build and run the frontend
- Fix in the Dockerfile:
	- Make use of the new script
	- Remove the build step
	- Remove unneeded steps: env, mkdir and copy of package.json